### PR TITLE
Add callback queue generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: Kneelawk/marionette-rt
-          ref: queues
+          ref: main
           path: rt
       - name: setup jdk ${{ matrix.java }}
         uses: actions/setup-java@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: Kneelawk/marionette-rt
-          ref: main
+          ref: queues
           path: rt
       - name: setup jdk ${{ matrix.java }}
         uses: actions/setup-java@v1

--- a/src/main/kotlin/com/kneelawk/marionette/gradle/MarionettePlugin.kt
+++ b/src/main/kotlin/com/kneelawk/marionette/gradle/MarionettePlugin.kt
@@ -78,6 +78,9 @@ class MarionettePlugin : Plugin<Project> {
             commonSignals = testSet.commonSignals
             clientSignals = testSet.clientSignals
             serverSignals = testSet.serverSignals
+            commonQueues = testSet.commonQueues
+            clientQueues = testSet.clientQueues
+            serverQueues = testSet.serverQueues
         }
     }
 

--- a/src/main/kotlin/com/kneelawk/marionette/gradle/MarionetteSourceGenerator.kt
+++ b/src/main/kotlin/com/kneelawk/marionette/gradle/MarionetteSourceGenerator.kt
@@ -482,7 +482,7 @@ open class MarionetteSourceGenerator @Inject constructor(private val objectFacto
         val imports = ImportResolver()
         val returnType = if (!rmi) imports.add(TypeName.fromString(callback.returnType)) else null
         val argumentTypes = callback.arguments.map { imports.add(TypeName.fromString(it)) }
-        val exceptionTypes = callback.exceptions.map { imports.add(TypeName.fromString(it)) }
+        val exceptionTypes = if (!rmi) callback.exceptions.map { imports.add(TypeName.fromString(it)) } else null
         val remoteException = if (rmi) imports.add(remoteExceptionType) else null
 
         val packageName1 = callback.packageName ?: packageName
@@ -495,11 +495,10 @@ open class MarionetteSourceGenerator @Inject constructor(private val objectFacto
             .importNames(imports.getImports(packageName1))
             .remote(rmi)
             .parameterTypes(argumentTypes.map { imports[it] })
-            .exceptionTypes(exceptionTypes.map { imports[it] })
-
-        if (remoteException != null && !exceptionTypes.contains(remoteException)) tData.exceptionType(imports[remoteException])
 
         tData.returnType(returnType?.let { imports[it] } ?: "void")
+        exceptionTypes?.let { et -> tData.exceptionTypes(et.map { imports[it] }) }
+        remoteException?.let { tData.exceptionType(imports[it]) }
 
         generate(
             engine,

--- a/src/main/kotlin/com/kneelawk/marionette/gradle/MarionetteTestSet.kt
+++ b/src/main/kotlin/com/kneelawk/marionette/gradle/MarionetteTestSet.kt
@@ -1,7 +1,7 @@
 package com.kneelawk.marionette.gradle
 
+import com.kneelawk.marionette.gradle.callback.QueueCallback
 import com.kneelawk.marionette.gradle.names.MarionetteNames
-import com.kneelawk.marionette.gradle.signal.MarionetteSignal
 import com.kneelawk.marionette.gradle.signal.MarionetteSignals
 import groovy.lang.Closure
 import org.gradle.api.Action
@@ -19,6 +19,12 @@ open class MarionetteTestSet @Inject constructor(private val name: String, priva
     val commonSignals: MarionetteSignals = objectFactory.newInstance(MarionetteSignals::class.java)
     val clientSignals: MarionetteSignals = objectFactory.newInstance(MarionetteSignals::class.java)
     val serverSignals: MarionetteSignals = objectFactory.newInstance(MarionetteSignals::class.java)
+    val commonQueues: NamedDomainObjectContainer<QueueCallback> =
+        objectFactory.domainObjectContainer(QueueCallback::class.java)
+    val clientQueues: NamedDomainObjectContainer<QueueCallback> =
+        objectFactory.domainObjectContainer(QueueCallback::class.java)
+    val serverQueues: NamedDomainObjectContainer<QueueCallback> =
+        objectFactory.domainObjectContainer(QueueCallback::class.java)
 
     override fun getName(): String {
         return name
@@ -45,11 +51,38 @@ open class MarionetteTestSet @Inject constructor(private val name: String, priva
         action.execute(commonSignals)
     }
 
+    fun commonSignals(closure: Closure<Any>) {
+        closure.delegate = commonSignals
+        closure.call(commonSignals)
+    }
+
     fun clientSignals(action: Action<MarionetteSignals>) {
         action.execute(clientSignals)
     }
 
+    fun clientSignals(closure: Closure<Any>) {
+        closure.delegate = clientSignals
+        closure.call(clientSignals)
+    }
+
     fun serverSignals(action: Action<MarionetteSignals>) {
         action.execute(serverSignals)
+    }
+
+    fun serverSignals(closure: Closure<Any>) {
+        closure.delegate = serverSignals
+        closure.call(serverSignals)
+    }
+
+    fun commonQueues(action: Action<NamedDomainObjectContainer<QueueCallback>>) {
+        action.execute(commonQueues)
+    }
+
+    fun clientQueues(action: Action<NamedDomainObjectContainer<QueueCallback>>) {
+        action.execute(clientQueues)
+    }
+
+    fun serverQueues(action: Action<NamedDomainObjectContainer<QueueCallback>>) {
+        action.execute(serverQueues)
     }
 }

--- a/src/main/kotlin/com/kneelawk/marionette/gradle/TypeName.kt
+++ b/src/main/kotlin/com/kneelawk/marionette/gradle/TypeName.kt
@@ -6,12 +6,12 @@ import java.util.regex.Pattern
 
 data class TypeName(val packageName: String, val className: String) : Named {
     companion object {
-        val PRIMITIVE_TO_WRAPPER: ImmutableMap<String, TypeName>
-        val WRAPPER_TO_PRIMITIVE: ImmutableMap<TypeName, String>
+        val PRIMITIVE_TO_WRAPPER: ImmutableMap<TypeName, TypeName>
+        val WRAPPER_TO_PRIMITIVE: ImmutableMap<TypeName, TypeName>
 
         init {
-            val p2wb = ImmutableMap.builder<String, TypeName>()
-            val w2pb = ImmutableMap.builder<TypeName, String>()
+            val p2wb = ImmutableMap.builder<TypeName, TypeName>()
+            val w2pb = ImmutableMap.builder<TypeName, TypeName>()
             setup(p2wb, w2pb, "byte" to "Byte")
             setup(p2wb, w2pb, "char" to "Character")
             setup(p2wb, w2pb, "short" to "Short")
@@ -44,18 +44,19 @@ data class TypeName(val packageName: String, val className: String) : Named {
         }
 
         private fun setup(
-            p2wb: ImmutableMap.Builder<String, TypeName>,
-            w2pb: ImmutableMap.Builder<TypeName, String>,
+            p2wb: ImmutableMap.Builder<TypeName, TypeName>,
+            w2pb: ImmutableMap.Builder<TypeName, TypeName>,
             p2w: Pair<String, String>
         ) {
+            val primitive = TypeName("", p2w.first)
             val wrapper = TypeName("java.lang", p2w.second)
-            p2wb.put(p2w.first, wrapper)
-            w2pb.put(wrapper, p2w.first)
+            p2wb.put(primitive, wrapper)
+            w2pb.put(wrapper, primitive)
         }
     }
 
     val primitive by lazy { WRAPPER_TO_PRIMITIVE[this] }
-    val wrapper by lazy { PRIMITIVE_TO_WRAPPER[className] }
+    val wrapper by lazy { PRIMITIVE_TO_WRAPPER[this] }
     val qualified = if (packageName.isEmpty()) className else "$packageName.$className"
 
     override fun getName(): String {

--- a/src/main/kotlin/com/kneelawk/marionette/gradle/TypeName.kt
+++ b/src/main/kotlin/com/kneelawk/marionette/gradle/TypeName.kt
@@ -1,0 +1,64 @@
+package com.kneelawk.marionette.gradle
+
+import com.google.common.collect.ImmutableMap
+import org.gradle.api.Named
+import java.util.regex.Pattern
+
+data class TypeName(val packageName: String, val className: String) : Named {
+    companion object {
+        val PRIMITIVE_TO_WRAPPER: ImmutableMap<String, TypeName>
+        val WRAPPER_TO_PRIMITIVE: ImmutableMap<TypeName, String>
+
+        init {
+            val p2wb = ImmutableMap.builder<String, TypeName>()
+            val w2pb = ImmutableMap.builder<TypeName, String>()
+            setup(p2wb, w2pb, "byte" to "Byte")
+            setup(p2wb, w2pb, "char" to "Character")
+            setup(p2wb, w2pb, "short" to "Short")
+            setup(p2wb, w2pb, "int" to "Integer")
+            setup(p2wb, w2pb, "long" to "Long")
+            setup(p2wb, w2pb, "float" to "Float")
+            setup(p2wb, w2pb, "double" to "Double")
+            setup(p2wb, w2pb, "boolean" to "Boolean")
+            setup(p2wb, w2pb, "void" to "Void")
+            PRIMITIVE_TO_WRAPPER = p2wb.build()
+            WRAPPER_TO_PRIMITIVE = w2pb.build()
+        }
+
+        private val PACKAGE_SEPARATOR = Pattern.compile("\\.[A-Z]")
+
+        fun fromString(qualified: String): TypeName {
+            val match = PACKAGE_SEPARATOR.matcher(qualified)
+            return if (match.find()) {
+                TypeName(qualified.substring(0, match.start()), qualified.substring(match.start() + 1))
+            } else {
+                val index = qualified.lastIndexOf('.')
+                if (index == -1) {
+                    // must be a primitive
+                    TypeName("", qualified)
+                } else {
+                    // the class name is not capitalized
+                    TypeName(qualified.substring(0, index), qualified.substring(index + 1))
+                }
+            }
+        }
+
+        private fun setup(
+            p2wb: ImmutableMap.Builder<String, TypeName>,
+            w2pb: ImmutableMap.Builder<TypeName, String>,
+            p2w: Pair<String, String>
+        ) {
+            val wrapper = TypeName("java.lang", p2w.second)
+            p2wb.put(p2w.first, wrapper)
+            w2pb.put(wrapper, p2w.first)
+        }
+    }
+
+    val primitive by lazy { WRAPPER_TO_PRIMITIVE[this] }
+    val wrapper by lazy { PRIMITIVE_TO_WRAPPER[className] }
+    val qualified = if (packageName.isEmpty()) className else "$packageName.$className"
+
+    override fun getName(): String {
+        return qualified
+    }
+}

--- a/src/main/kotlin/com/kneelawk/marionette/gradle/callback/QueueCallback.kt
+++ b/src/main/kotlin/com/kneelawk/marionette/gradle/callback/QueueCallback.kt
@@ -1,0 +1,53 @@
+package com.kneelawk.marionette.gradle.callback
+
+import org.gradle.api.Named
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import java.io.Serializable
+import javax.inject.Inject
+
+open class QueueCallback @Inject constructor(private val name: String, private val objectFactory: ObjectFactory) :
+    Named, Serializable {
+    @get:Input
+    var returnType = "void"
+
+    @get:Input
+    var arguments = mutableListOf<String>()
+
+    @get:Input
+    var exceptions = mutableListOf<String>()
+
+    @get:Input
+    @get:Optional
+    var packageName: String? = null
+
+    @get:Input
+    @get:Optional
+    var className: String? = null
+
+    @Input
+    override fun getName(): String {
+        return name
+    }
+
+    fun returnType(string: String) {
+        returnType = string
+    }
+
+    fun argument(string: String) {
+        arguments.add(string)
+    }
+
+    fun exception(string: String) {
+        exceptions.add(string)
+    }
+
+    fun packageName(string: String?) {
+        packageName = string
+    }
+
+    fun className(string: String?) {
+        className = string
+    }
+}

--- a/src/main/kotlin/com/kneelawk/marionette/gradle/names/MarionetteProxyNames.kt
+++ b/src/main/kotlin/com/kneelawk/marionette/gradle/names/MarionetteProxyNames.kt
@@ -26,4 +26,58 @@ open class MarionetteProxyNames {
 
     @get:Input
     var apiServerAccessPackage = "com.kneelawk.marionette.gen.api.server"
+
+    @get:Input
+    var apiCommonQueueCallbackPrefix = "RMI"
+
+    @get:Input
+    var apiCommonQueueCallbackSuffix = "Callback"
+
+    @get:Input
+    var apiCommonQueueCallbackPackage = "com.kneelawk.marionette.gen.api.callback.queue"
+
+    @get:Input
+    var testCommonQueueCallbackPrefix = ""
+
+    @get:Input
+    var testCommonQueueCallbackSuffix = "Callback"
+
+    @get:Input
+    var testCommonQueueCallbackPackage = "com.kneelawk.marionette.gen.callback.queue"
+
+    @get:Input
+    var apiClientQueueCallbackPrefix = "RMI"
+
+    @get:Input
+    var apiClientQueueCallbackSuffix = "Callback"
+
+    @get:Input
+    var apiClientQueueCallbackPackage = "com.kneelawk.marionette.gen.api.client.callback.queue"
+
+    @get:Input
+    var testClientQueueCallbackPrefix = ""
+
+    @get:Input
+    var testClientQueueCallbackSuffix = "Callback"
+
+    @get:Input
+    var testClientQueueCallbackPackage = "com.kneelawk.marionette.gen.client.callback.queue"
+
+    @get:Input
+    var apiServerQueueCallbackPrefix = "RMI"
+
+    @get:Input
+    var apiServerQueueCallbackSuffix = "Callback"
+
+    @get:Input
+    var apiServerQueueCallbackPackage = "com.kneelawk.marionette.gen.api.callback.queue"
+
+    @get:Input
+    var testServerQueueCallbackPrefix = ""
+
+    @get:Input
+    var testServerQueueCallbackSuffix = "Callback"
+
+    @get:Input
+    var testServerQueueCallbackPackage = "com.kneelawk.marionette.gen.callback.queue"
 }

--- a/src/main/kotlin/com/kneelawk/marionette/gradle/names/MarionetteUtilNames.kt
+++ b/src/main/kotlin/com/kneelawk/marionette/gradle/names/MarionetteUtilNames.kt
@@ -14,4 +14,16 @@ open class MarionetteUtilNames {
 
     @get:Input
     var serverGlobalSignalsPackage = "com.kneelawk.marionette.gen.mod.server"
+
+    @get:Input
+    var clientGlobalQueuesName = "ClientGlobalQueues"
+
+    @get:Input
+    var clientGlobalQueuesPackage = "com.kneelawk.marionette.gen.mod.client"
+
+    @get:Input
+    var serverGlobalQueuesName = "ServerGlobalQueues"
+
+    @get:Input
+    var serverGlobalQueuesPackage = "com.kneelawk.marionette.gen.mod.server"
 }

--- a/src/test/kotlin/com/kneelawk/marionette/gradle/ImportResolverTests.kt
+++ b/src/test/kotlin/com/kneelawk/marionette/gradle/ImportResolverTests.kt
@@ -30,7 +30,7 @@ class ImportResolverTests : StringSpec({
     "it should give an import if only one name exists with that unqualified name" {
         val i = ImportResolver()
         val baz = i.add("foo.bar", "Baz")
-        i.getImport(baz) shouldBe "foo.bar"
+        i.getImport(baz) shouldBe "foo.bar.Baz"
     }
 
     "it should not give an import if more than one name exists with that unqualified name" {
@@ -44,7 +44,7 @@ class ImportResolverTests : StringSpec({
     "it should give an import if only one name exists with that unqualified name and the current package is different" {
         val i = ImportResolver()
         val baz = i.add("foo.bar", "Baz")
-        i.getImport(baz, "qux") shouldBe "foo.bar"
+        i.getImport(baz, "qux") shouldBe "foo.bar.Baz"
     }
 
     "it should not give an import if more than one name exists with that unqualified name but the current package is different" {
@@ -78,6 +78,23 @@ class ImportResolverTests : StringSpec({
 
     "it should not list imports in the same package" {
         val i = ImportResolver()
+        i.add("foo.bar", "Baz")
+        i.add("qux.quux", "Quuz")
+        i.getImports("foo.bar") shouldContainExactly listOf("qux.quux.Quuz")
+    }
+
+    "it should not list imports for primitive types" {
+        val i = ImportResolver()
+        i.add("", "void")
+        i.add("", "int")
+        i.add("foo.bar", "Baz")
+        i.getImports() shouldContainExactly listOf("foo.bar.Baz")
+    }
+
+    "it should not list imports for primitive types or ones from the same package" {
+        val i = ImportResolver()
+        i.add("", "void")
+        i.add("", "int")
         i.add("foo.bar", "Baz")
         i.add("qux.quux", "Quuz")
         i.getImports("foo.bar") shouldContainExactly listOf("qux.quux.Quuz")

--- a/src/test/kotlin/com/kneelawk/marionette/gradle/TypeNameTests.kt
+++ b/src/test/kotlin/com/kneelawk/marionette/gradle/TypeNameTests.kt
@@ -1,0 +1,37 @@
+package com.kneelawk.marionette.gradle
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class TypeNameTests : StringSpec({
+    "it should qualify names" {
+        val t = TypeName("foo.bar", "Baz")
+        t.qualified shouldBe "foo.bar.Baz"
+    }
+
+    "it should be able to wrap primitives" {
+        val t = TypeName("", "int")
+        t.wrapper shouldBe TypeName("java.lang", "Integer")
+    }
+
+    "it should be able to unwrap wrappers" {
+        val t = TypeName("java.lang", "Double")
+        t.primitive shouldBe TypeName("", "double")
+    }
+
+    "it should parse qualified names" {
+        TypeName.fromString("foo.bar.Baz") shouldBe TypeName("foo.bar", "Baz")
+    }
+
+    "it should parse qualified names of nested classes" {
+        TypeName.fromString("foo.bar.Baz.Qux") shouldBe TypeName("foo.bar", "Baz.Qux")
+    }
+
+    "it should parse qualified names of lower-case classes" {
+        TypeName.fromString("foo.bar.baz") shouldBe TypeName("foo.bar", "baz")
+    }
+
+    "it should parse primitive names" {
+        TypeName.fromString("float") shouldBe TypeName("", "float")
+    }
+})


### PR DESCRIPTION
This pr adds the ability for the gradle plugin to generate callback queues that allow a Minecraft process to call a control callback and give it arguments. Currently all arguments must be serializable, but when proxies are released, arguments will be able to be proxied as well.